### PR TITLE
Create docker development env

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-16
+
+ARG USERNAME=node
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN mkdir -p /app/node_modules
+
+RUN chown -R $USER_UID:$USER_GID /home/$USERNAME /app;
+
+RUN apt-get update \
+   && apt-get -y install --no-install-recommends git-lfs \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+{
+  "name": "AmemoZING",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "node",
+  "workspaceFolder": "/app",
+
+  // Set *default* container specific settings.json values on container create.
+  "settings": {
+    "terminal.integrated.defaultProfile.linux": "bash"
+  },
+
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": [
+    "mhutchie.git-graph",
+    "eamodio.gitlens",
+    "github.vscode-pull-request-github",
+    "esbenp.prettier-vscode",
+    "shinnn.stylelint",
+    "hex-ci.stylelint-plus",
+  ],
+
+  // Uncomment the next line if you want start specific services in your Docker Compose config.
+  // "runServices": [],
+
+  // Uncomment the line below if you want to keep your containers running after VS Code shuts down.
+  // "shutdownAction": "none",
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  // "postCreateCommand": "yarn install",
+
+  // Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+  "remoteUser": "node"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3'
+services:
+  node:
+    user: node
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ..:/app:delegated
+      - node_modules:/app/node_modules
+    tty: true
+
+  mongo:
+    image: mongo:5.0.6
+    restart: always
+    ports:
+      - 27017:27017
+    volumes:
+      - /data/db
+
+volumes:
+  node_modules:


### PR DESCRIPTION
## やったこと
Docker での開発環境の作成

## 起動方法
1. Docker Desctop for Windows もしくは Docker Desctop for Mac をインストールする
2. vsCode で「Remote Development」extension をインストールする
3. vsCode で「Docker」extension をインストールする
4. 「Open folder in Container」でこのリポジトリを選択する
5. `yarn install` を実行する
6. `yarn dev` を実行する
8. http://localhost:3000 にアクセスする